### PR TITLE
Deploy model v2 by updating streamlit app

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To learn more, please refer to Tito Joker's [medium article](https://towardsdata
 
 ## Trained models
 1. [Tito Joker v1 (OpenAI GPT-2)](https://storage.googleapis.com/joke-generator-model1/model1.zip)
-2. [Tito Joker v2 (OpenAI GPT-2)](https://storage.cloud.google.com/joke-generator-model1/model2.zip)
+2. [Tito Joker v2 (OpenAI GPT-2)](https://storage.googleapis.com/joke-generator-model1/model2.zip)
 
 ## Acknowledgments
 

--- a/run_generation.py
+++ b/run_generation.py
@@ -324,7 +324,9 @@ def generate_text(args, model, tokenizer):
         )
         outputs = outputs[:, len(context_tokens) :].tolist()
         text_candidates = []
+        stop_token_id = tokenizer._convert_token_to_id(args.stop_token)
         for out in outputs:
+            out = out[: out.index(stop_token_id)]
             text = tokenizer.decode(
                 out, clean_up_tokenization_spaces=False, skip_special_tokens=False
             )

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 wget https://storage.googleapis.com/joke-generator-model1/model1.zip
 unzip model1.zip
-wget https://storage.cloud.google.com/joke-generator-model1/model2.zip
+wget https://storage.googleapis.com/joke-generator-model1/model2.zip
 unzip model2.zip
 pip install -r requirements.txt
 python -m spacy download en_core_web_sm

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,6 @@
 wget https://storage.googleapis.com/joke-generator-model1/model1.zip
 unzip model1.zip
+wget https://storage.cloud.google.com/joke-generator-model1/model2.zip
+unzip model2.zip
 pip install -r requirements.txt
 python -m spacy download en_core_web_sm

--- a/tito_joker_app.py
+++ b/tito_joker_app.py
@@ -49,8 +49,8 @@ JOKES_CSV_COLUMNS = [
     "not_funny",
 ]
 MODEL_VERSION_MAPPING = {
-    "Tito Joker v1": "./model1/",
-    "Tito Joker v2": "./model2/",
+    "Tito Joker v1": {"model_path":"./model1/", "stop_token": "<eoj>"},
+    "Tito Joker v2": {"model_path": "./model2/", "stop_token": "<|endoftext|>"},
 }
 
 if __name__ == "__main__":
@@ -97,7 +97,8 @@ if __name__ == "__main__":
     args = get_config(CONFIG)
     args.length = num_tokens
     args.num_samples = num_samples
-    args.model_name_or_path = MODEL_VERSION_MAPPING[model_version]
+    args.model_name_or_path = MODEL_VERSION_MAPPING[model_version]["model_path"]
+    args.stop_token = MODEL_VERSION_MAPPING[model_version]["stop_token"]
 
     if SEED_GENERATOR:
         # This ensures that samples are unique, even with similar prompts

--- a/tito_joker_app.py
+++ b/tito_joker_app.py
@@ -48,7 +48,10 @@ JOKES_CSV_COLUMNS = [
     "funny",
     "not_funny",
 ]
-
+MODEL_VERSION_MAPPING = {
+    "Tito Joker v1": "./model1/",
+    "Tito Joker v2": "./model2/",
+}
 
 if __name__ == "__main__":
 
@@ -62,6 +65,10 @@ if __name__ == "__main__":
     )
 
     st.sidebar.markdown("### Settings")
+
+    model_version = st.sidebar.selectbox(
+        "Model version", ["Tito Joker v1", "Tito Joker v2"], index=1
+    )
 
     num_tokens = st.sidebar.selectbox(
         "Max token count for output", [10, 20, 40, 80, 160], index=2
@@ -90,6 +97,7 @@ if __name__ == "__main__":
     args = get_config(CONFIG)
     args.length = num_tokens
     args.num_samples = num_samples
+    args.model_name_or_path = MODEL_VERSION_MAPPING[model_version]
 
     if SEED_GENERATOR:
         # This ensures that samples are unique, even with similar prompts


### PR DESCRIPTION
Closes issue #20

**The additional changes in the source code were required:**
1. Drop down in the streamlit app to choose the model version to run
2. Dynamically setting the model source dir and `stop_token`, depending on which model is used
3. Apply stop token truncation at the ID level. Necessary since v2 uses a special token as it's eos tag